### PR TITLE
adjust mounting hole distance in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Depending on if you bought a OpenDTU Fusion board that has OpenDTU already flash
 
 ## Specs
 
-- Size: 5.5cm x 5.5cm, 4x M3 corner mounting holes (46mm pitch) (if you wish to design a case for this PCB yourself a 3D model step file is available [here](3d/OpenDTUFusion2.step))
+- Size: 5.5cm x 5.5cm, 4x M3 corner mounting holes (~47mm pitch) (if you wish to design a case for this PCB yourself a 3D model step file is available [here](3d/OpenDTUFusion2.step))
 - Power: 5V via USB-C or 5V DC via screw terminal, selectable by a 2.54mm jumper
 - Wireless: UF.L/IPEX Antenna connectors to enable you to either use self-adhering PCB-Antennas or SMA-antennas outside your case for best send/receive performance
 (IMPORTANT: these are full-size U.FL/IPEX connectors, not the 'mini' versions found on some newer laptop Wifi cards, which are often called U.FL/IPEX/MHF 4 or Gen4)


### PR DESCRIPTION
[Thanks for this awesome product. With regard to this pull request: Thanks for adding M3 holes rather than M2.5 or even M2]

In the current step model FreeCAD measures a distance of 46.74mm, while the holes are 3.2mm in diameter. on the actual board on my desk the holes are smaller than that, maybe 3.05mm. the pitch matches the theoretical pitch from the step model very closely: 46.8mm. in any case: the README should probably read 47mm, not 46mm.